### PR TITLE
chore: add msapp comment to HistoryScreen

### DIFF
--- a/HistoryScreen.json
+++ b/HistoryScreen.json
@@ -1,4 +1,4 @@
-HistoryScreen.msapp.json
+// HistoryScreen.msapp.json
 {
   "Screen": "HistoryScreen",
   "Properties": {


### PR DESCRIPTION
## Summary
- add missing .msapp comment header to HistoryScreen

## Testing
- `npm test -- --watchAll=false` *(fails: Could not read package.json)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_688fb883472c8332aaff765d48578fd0