### PR TITLE
feat: enable file selection with hidden AddMediaButton

### DIFF
--- a/UploadScreen.json
+++ b/UploadScreen.json
@@ -86,6 +86,12 @@
           "Tooltip": "Take Photo"
         },
         {
+          "Type": "AddMediaButton",
+          "Name": "addPicture1",
+          "Visible": false,
+          "OnChange": "Set(varPhoto, addPicture1.Media); Set(varFileName, addPicture1.FileName)"
+        },
+        {
           "Type": "Button",
           "Name": "btnChooseFile",
           "Text": "Choose File",


### PR DESCRIPTION
## Summary
- add hidden AddMediaButton to `UploadScreen` that saves selected media and filename
- keep Choose File button triggering the hidden picker

## Testing
- `npm test -- --watchAll=false` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_b_688fbb434d1c83329187995230e61d15